### PR TITLE
fix 'rm -r' to 'rm -rf' in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ENV TZ Asia/Tokyo
 WORKDIR /tmp/nuxt
 COPY ./ /app/
 WORKDIR /app
-RUN rm -r .nuxt .git* .editorconfig .idea *.md
+RUN rm -rf .nuxt .git* .editorconfig .idea *.md
 RUN yarn
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 
 FROM nuxt_dev as nuxt_prod
 # 極力imageを削る
-RUN rm -r test .eslintrc.js .prettierrc jest.config.js
+RUN rm -rf test .eslintrc.js .prettierrc jest.config.js
 RUN yarn build


### PR DESCRIPTION
Dockerfileの `rm -r 〇〇` などとしていたところで以下のようなエラーが出ました。
```
rm: can't remove '.nuxt': No such file or directory
rm: can't remove '.editorconfig': No such file or directory
rm: can't remove '.idea': No such file or directory
```
`rm -rf` とすれば治ったので、ご確認よろしくお願いいたします。